### PR TITLE
make the static files after build accessible in any baseurl, not just the root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "little-fighter-j",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "scripts": {
     "init": "npm i --registry https://registry.npmmirror.com",
     "start": "node scripts/start.js",

--- a/src/DittoImpl/Importer.ts
+++ b/src/DittoImpl/Importer.ts
@@ -23,6 +23,12 @@ function get_possible_url_list(list: string[]): string[] {
     for (const root of roots)
       ret.push(root + item);
   }
+
+  ret.forEach((item, index) => {
+    if (item.startsWith("/")) {
+      ret[index] = "." + item;
+    }
+  });
   return ret;
 }
 


### PR DESCRIPTION
This is almost the best web-based remake of LF2 I've ever seen, and it even restores the stage mode nearly perfectly. However, surprisingly, it seems to have very few followers at the moment. I made a small modification to allow the static files after build to be accessed from any directory. This way, you can directly host the compiled static files on GitHub Pages, which is quite interesting and more convenient for everyone to use. I'm not sure if this modification will affect your overall plan, like connect mode. If it does, please feel free to ignore this PR.